### PR TITLE
fix: remove global scope 'using namespace' in header

### DIFF
--- a/Plugin/interfaces/pipelineSlam.h
+++ b/Plugin/interfaces/pipelineSlam.h
@@ -54,10 +54,6 @@
 //#define USE_IMAGES_SET
 //#define VIDEO_INPUT
 
-using namespace SolAR;
-using namespace SolAR::datastructure;
-using namespace SolAR::api;
-
 namespace xpcf = org::bcom::xpcf;
 
 namespace SolAR {


### PR DESCRIPTION
Discouraged practice
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf7-dont-write-using-namespace-at-global-scope-in-a-header-file