### PR TITLE
fix: handle error returned by getKeyFrame() on map loading

### DIFF
--- a/SolARPipeline_SLAM/src/component.cpp
+++ b/SolARPipeline_SLAM/src/component.cpp
@@ -108,8 +108,12 @@ FrameworkReturnCode PipelineSlam::start(void* imageDataBuffer)
 	// Load map from file
 	if (m_mapper->loadFromFile() == FrameworkReturnCode::_SUCCESS) {
 		LOG_INFO("Load map done!");
+
+		if (m_keyframesManager->getKeyframe(0, m_keyframe2) != FrameworkReturnCode::_SUCCESS)
+		{
+			return FrameworkReturnCode::_ERROR_;
+		}
 		m_bootstrapOk = true;
-		m_keyframesManager->getKeyframe(0, m_keyframe2);
 		m_tracking->updateReferenceKeyframe(m_keyframe2);
 	}
 	else

--- a/SolARPipeline_SLAM/src/component.cpp
+++ b/SolARPipeline_SLAM/src/component.cpp
@@ -108,7 +108,10 @@ FrameworkReturnCode PipelineSlam::start(void* imageDataBuffer)
 	// Load map from file
 	if (m_mapper->loadFromFile() == FrameworkReturnCode::_SUCCESS) {
 		LOG_INFO("Load map done!");
+	}
 
+	if (m_pointCloudManager->getNbPoints() != 0)
+	{
 		if (m_keyframesManager->getKeyframe(0, m_keyframe2) != FrameworkReturnCode::_SUCCESS)
 		{
 			return FrameworkReturnCode::_ERROR_;
@@ -117,7 +120,9 @@ FrameworkReturnCode PipelineSlam::start(void* imageDataBuffer)
 		m_tracking->updateReferenceKeyframe(m_keyframe2);
 	}
 	else
+	{
 		LOG_INFO("Initialization from scratch");
+	}
 
     // create and start threads
     auto getCameraImagesThread = [this](){getCameraImages();};


### PR DESCRIPTION
This will prevent a crash occuring when the returned key frame is null
and accessed later on.