### PR TITLE
Fix JenkinsFile where both CI pipeline had the same name

### DIFF
--- a/JenkinsFile
+++ b/JenkinsFile
@@ -9,7 +9,7 @@ SolArModulePipeline {
 }    
 
 SolArModulePipeline {
-    moduleName="SolARPipeline_SLAM"
+    moduleName="SolARSample_SLAM"
     dirName="SolARBuild"
     buildDir="SolARSample_SLAM_Mono,SolARSample_SLAM_Multi,SolARPipeline_SLAM/tests/SolARPipelineTest_SLAM"
     makeTarget="install install_deps"


### PR DESCRIPTION
The CI pipeline dedicated to the sample package had the same name as the one used for the SolAR pipeline.
This resulted in only one artifact being released.